### PR TITLE
Fix mnt report UI

### DIFF
--- a/src/model/MTNOrderModel.ts
+++ b/src/model/MTNOrderModel.ts
@@ -1,5 +1,7 @@
 export interface MntOrderModel {
   id: number;
+  /** Underlying order id used for audit history */
+  order_id?: number;
   mnt_number: string;
   created_at: string;
   user_username: string | null;


### PR DESCRIPTION
## Summary
- replace DataGrid usage in MNT report with a MUI Table
- display invoice number, price, admin and user columns
- show `__` if user name is missing
- wire up table pagination using existing hooks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee3c8f0848331a5df44c996704cb0